### PR TITLE
Add all the GET endpoints and corresponding tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,4 +29,26 @@ app.get('/user', async (request, response) => {
   }
 });
 
+app.get('/projects/:id', async (request, response) => {
+  const userId = request.params.id;
+  const userProjects = await database('projects').where('user_id', userId).select();
+  
+  return response.status(200).json(userProjects)
+})
+
+app.get('/palettes/:id', async (request, response) => {
+  const { id } = request.params
+  const projectPalettes = await database('palettes').where('project_id', id).select();
+
+  return response.status(200).json(projectPalettes)
+})
+
+app.get('/palettes', async (request, response) => {
+  const palettes = await database('palettes').select();
+
+  return response.status(200).json(palettes)
+})
+
+
+
 module.exports = app;

--- a/app.test.js
+++ b/app.test.js
@@ -39,6 +39,38 @@ describe('Server', () => {
       expect(response.status).toBe(400);
       expect(response.body.error).toEqual("Unable to verify user.");
     });
-  
   });
+
+  describe('GET /projects/:id', () => {
+    it('should return a 200 status code and all the projects associated with the user via user_id', async () => {
+      const user = await database('users').select().first();
+      const response = await request(app).get(`/projects/${user.id}`);
+      const expectedProjects = await database('projects').where('user_id', user.id).select();
+      expect(response.body[0].name).toEqual(expectedProjects[0].name);
+    })
+  })
+
+  describe('GET /palettes/:id', () => {
+    it('should return a 200 status code and all the palettes associated with the project via project_id', async () => {
+      const { id } = await database('projects').first();
+      const response = await request(app).get(`/palettes/${id}`);
+      const expectedPalettes = await database('palettes').where('project_id', id).select();
+      const { name, hex_codes } = response.body[0];
+
+      expect(name).toEqual(expectedPalettes[0].name)
+      expect(hex_codes).toEqual(expectedPalettes[0].hex_codes)
+    })
+  })
+
+  describe('GET /palettes', () => {
+    it('should return a 200 status code and all the palettes ', async () => {
+      const response = await request(app).get('/palettes');
+      const expectedPalettes = await database('palettes').select();
+      const { name, hex_codes } = response.body[0];
+
+      expect(name).toEqual(expectedPalettes[0].name)
+      expect(hex_codes).toEqual(expectedPalettes[0].hex_codes)
+    })
+  })
+
 });


### PR DESCRIPTION
Co-Author: Djavan Munroe <DjavanM24@gmail.com>

## Problem 
As a developer we had a database with no way to fetch information.

## Solution
Created 4 GET request endpoints:
/user
/projects/:id
/palettes
/palettes/:id

all of these endpoints were created via TDD and subsequently have the necessary happy/sad path tests.