### PR TITLE
Add patch request for projects and palettes name change

### DIFF
--- a/app.js
+++ b/app.js
@@ -119,8 +119,34 @@ app.delete('/projects/:id', async (request, response) => {
   } else {
     return response.status(404).send({
       error: 'This project does not exist.'
-    })
-  }
-})
+    });
+  };
+});
+
+app.patch('/palettes/:id', async (request, response) => {
+  const { id } = request.params;
+  const newName = request.body.name;
+  const paletteExists = await database('palettes').where('id', id).first();
+  if(paletteExists) {
+    await database('palettes').where('id', id).update({name: newName});
+    const updatedPalette = await database('palettes').where('id', id).first();
+    return response.status(200).send(updatedPalette);
+  } else {
+    return response.status(404).send({ error: 'This palette does not exist.' });
+  };
+});
+
+app.patch('/projects/:id', async (request, response) => {
+  const { id } = request.params;
+  const newName = request.body.name;
+  const projectExists = await database('projects').where('id', id).first();
+  if(projectExists) {
+    await database('projects').where('id', id).update({name: newName});
+    const updatedProject = await database('projects').where('id', id).first();
+    return response.status(200).send(updatedProject);
+  } else {
+    return response.status(404).send({ error: 'This project does not exist.' });
+  };
+});
 
 module.exports = app;

--- a/app.test.js
+++ b/app.test.js
@@ -141,8 +141,8 @@ describe('Server', () => {
       const response = await request(app).delete(`/palettes/${id}`);
 
       expect(response.status).toBe(204);
-    })
-  })
+    });
+  });
 
   describe('DELETE /projects/:id', () => {
     it('should delete a project and all its associated palettes return a 204 status code', async () => {
@@ -150,6 +150,24 @@ describe('Server', () => {
       const response = await request(app).delete(`/projects/${id}`);
 
       expect(response.status).toBe(204);
-    })
-  })
+    });
+  });
+
+  describe('PATCH /palettes/:id', () => {
+    it('should update a palette name and return a 200 status code', async () => {
+      const { id } = await database('palettes').first();
+      const response = await request(app).patch(`/palettes/${id}`).send({name: 'Palette Pat'});
+      expect(response.status).toBe(200);
+      expect(response.body.name).toEqual('Palette Pat');
+    });
+  });
+  
+  describe('PATCH /projects/:id', () => {
+    it('should update a project name and return a 200 status code', async () => {
+      const { id } = await database('projects').first();
+      const response = await request(app).patch(`/projects/${id}`).send({name: 'Project Pat'});
+      expect(response.status).toBe(200);
+      expect(response.body.name).toEqual('Project Pat');
+    });
+  });
 });


### PR DESCRIPTION
## Problem 
As a user, we would want to update the name of a project or a palette. 
As a developer, we would need an endpoint that allows us to patch a project's or palette's name in the database. 

## Solution
Add an endpoint for projects that takes in the project ID and the name you would like to change. 
Add an endpoint for palettes that takes in the palette ID and the name you would like to change.