### PR TITLE
Add a Custom  endpoint for pallete and corresponding tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,9 +44,14 @@ app.get('/palettes/:id', async (request, response) => {
 })
 
 app.get('/palettes', async (request, response) => {
-  const palettes = await database('palettes').select();
-
-  return response.status(200).json(palettes)
+  const { name } = request.query;
+  if(name) {
+    const queriedPalettes = await database('palettes').where('name', 'like', `%${name}%`).select();
+    return response.status(200).json(queriedPalettes)
+  } else {
+     const palettes = await database("palettes").select();
+     return response.status(200).json(palettes)
+  }
 });
 
 app.post('/user', async (request, response) => {

--- a/app.test.js
+++ b/app.test.js
@@ -170,4 +170,13 @@ describe('Server', () => {
       expect(response.body.name).toEqual('Project Pat');
     });
   });
+
+  describe("GET /palettes?name", () => {
+    it("should return a 200 status code and all the palettes that contain the given string", async () => {
+      const response = await request(app).get("/palettes?name=Warm");
+      const expectedPalettes = await database("palettes").where('name', 'like', '%Warm%').select();
+      
+      expect(response.body[0].name).toEqual(expectedPalettes[0].name)
+    });
+  });
 });


### PR DESCRIPTION
Co-Author: Djavan Munroe <DjavanM24@gmail.com>

##Problem
There is no way to search through the created palettes.

##Solution
Created a custom endpoint query @ /palettes?name=<string>.
Utilized TDD so the associated tests are present. 